### PR TITLE
[FIX] Fix the bug in class LandslideDataSet's default parameter: set.

### DIFF
--- a/dataset/landslide_dataset.py
+++ b/dataset/landslide_dataset.py
@@ -5,7 +5,7 @@ from torch.utils.data import DataLoader
 import h5py
 
 class LandslideDataSet(data.Dataset):
-    def __init__(self, data_dir, list_path, max_iters=None,set='label'):
+    def __init__(self, data_dir, list_path, max_iters=None,set='labeled'):
         self.list_path = list_path
         self.mean = [-0.4914, -0.3074, -0.1277, -0.0625, 0.0439, 0.0803, 0.0644, 0.0802, 0.3000, 0.4082, 0.0823, 0.0516, 0.3338, 0.7819]
         self.std = [0.9325, 0.8775, 0.8860, 0.8869, 0.8857, 0.8418, 0.8354, 0.8491, 0.9061, 1.6072, 0.8848, 0.9232, 0.9018, 1.2913]


### PR DESCRIPTION
The class LandslideDataSet has specified a wrong parameter 'label' as default.
That may lead to an error when creating a dataset.
I have corrected it.